### PR TITLE
Integration fixup for 0.0.5

### DIFF
--- a/src/statsig/evaluations_data_adapter.h
+++ b/src/statsig/evaluations_data_adapter.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+#include <optional>
 #include <string>
 
 #include "statsig_user.h"

--- a/src/statsig/internal/constants.cpp
+++ b/src/statsig/internal/constants.cpp
@@ -1,0 +1,8 @@
+#include "constants.h"
+
+namespace statsig::constants {
+
+const std::string kBadNetworkErr = "NetworkError_";
+const std::string kShutdownTimeoutExtra = "ShutdownTimeout";
+
+}

--- a/src/statsig/internal/constants.h
+++ b/src/statsig/internal/constants.h
@@ -1,37 +1,41 @@
 #pragma once
 
+#include <string>
+
+#include "statsig_compat/defines/module_definitions.h"
+
 namespace statsig::constants {
 
 // Statsig Metadata
-inline const char *kSdkVersion = "0.0.5";
+static const char *kSdkVersion = "0.0.5";
 
 // HTTP Endpoints
-inline const char *kEndpointInitialize = "/v1/initialize";
-inline const char *kEndpointLogEvent = "/v1/rgstr";
+static const char *kEndpointInitialize = "/v1/initialize";
+static const char *kEndpointLogEvent = "/v1/rgstr";
 
 // HTTP Misc
-inline const char *kContentTypeJson = "application/json";
-inline const char *kDefaultApi = "https://statsigapi.net";
-inline const int kInitializeRetryCount = 3;
-inline const int kLogEventRetryCount = 2;
+static const char *kContentTypeJson = "application/json";
+static const char *kDefaultApi = "https://statsigapi.net";
+static const int kInitializeRetryCount = 3;
+static const int kLogEventRetryCount = 2;
 
 // Caching
-inline const char *kCachedEvaluationsPrefix = "statsig.cached.evaluations.";
-inline const char *kStableIdKey = "stable_id";
-inline const int kMaxCachedEvaluationsCount = 10;
-inline const char *kCacheDirectory = "/tmp/statsig_cpp_client";
+static const char *kCachedEvaluationsPrefix = "statsig.cached.evaluations.";
+static const char *kStableIdKey = "stable_id";
+static const int kMaxCachedEvaluationsCount = 10;
+static const char *kCacheDirectory = "/tmp/statsig_cpp_client";
 
 // Logging
-inline const char *kCachedFailedEventPayloadPrefix = "statsig.failed_events.";
-inline const int kFailedEventPayloadRetryCount = 3;
-inline const int kMaxCachedFailedEventPayloadsCount = 5;
-inline const int kLoggingIntervalMs = 10000;
-inline const int kMaxQueuedEvents = 50;
-inline const int kMaxDiagnosticsMarkers = 30;
+static const char *kCachedFailedEventPayloadPrefix = "statsig.failed_events.";
+static const int kFailedEventPayloadRetryCount = 3;
+static const int kMaxCachedFailedEventPayloadsCount = 5;
+static const int kLoggingIntervalMs = 10000;
+static const int kMaxQueuedEvents = 50;
+static const int kMaxDiagnosticsMarkers = 30;
 
 // Error Reporting
-const std::string kBadNetworkErr = "NetworkError_";
-const std::string kShutdownTimeoutExtra = "ShutdownTimeout";
-inline const int kShutdownTimeoutErrorThresholdMs = 2000;
+STATSIG_EXPORT extern const std::string kBadNetworkErr;
+STATSIG_EXPORT extern const std::string kShutdownTimeoutExtra;
+static const int kShutdownTimeoutErrorThresholdMs = 2000;
 
 }

--- a/src/statsig/internal/diagnostic_markers.hpp
+++ b/src/statsig/internal/diagnostic_markers.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
+#include "../evaluation_details.h"
+#include "../statsig_result.h"
 #include "statsig_compat/primitives/json_value.hpp"
+#include "time.hpp"
 
 namespace statsig::internal::markers {
 

--- a/src/statsig/internal/diagnostics.cpp
+++ b/src/statsig/internal/diagnostics.cpp
@@ -1,0 +1,7 @@
+#include "diagnostics.hpp"
+
+namespace statsig::internal {
+
+Shareable<Diagnostics> Diagnostics::shareable_ = Shareable<Diagnostics>();
+
+}

--- a/src/statsig/internal/diagnostics.hpp
+++ b/src/statsig/internal/diagnostics.hpp
@@ -4,11 +4,16 @@
 #include <memory>
 #include <utility>
 #include <optional>
+#include <vector>
 
+#include "../statsig_user.h"
+#include "constants.h"
 #include "diagnostic_markers.hpp"
 #include "macros.hpp"
 #include "shareable.hpp"
+#include "statsig_compat/defines/module_definitions.h"
 #include "statsig_compat/output_logger/log.hpp"
+#include "statsig_event_internal.hpp"
 
 namespace statsig::internal {
 
@@ -76,7 +81,7 @@ class Diagnostics {
   Diagnostics &operator=(const Diagnostics &) = delete;
 
  private:
-  static Shareable<Diagnostics> shareable_;
+  STATSIG_EXPORT static Shareable<Diagnostics> shareable_;
 
   std::vector<JsonValue> markers_;
   std::mutex mutex_;
@@ -84,7 +89,5 @@ class Diagnostics {
 
   explicit Diagnostics() {}
 };
-
-Shareable<Diagnostics> Diagnostics::shareable_ = Shareable<Diagnostics>();
 
 }

--- a/src/statsig/internal/error_boundary.cpp
+++ b/src/statsig/internal/error_boundary.cpp
@@ -1,0 +1,7 @@
+#include "error_boundary.hpp"
+
+namespace statsig::internal {
+
+Shareable<ErrorBoundary> ErrorBoundary::shareable_ = Shareable<ErrorBoundary>();
+
+}

--- a/src/statsig/internal/error_boundary.hpp
+++ b/src/statsig/internal/error_boundary.hpp
@@ -4,15 +4,16 @@
 #include <unordered_map>
 #include <utility>
 
-#include "json_parser.hpp"
 #include "constants.h"
-#include "statsig_compat/network/network_client.hpp"
-#include "statsig_compat/constants/constants.h"
-#include "unordered_map_util.hpp"
 #include "error_boundary_request_args.h"
+#include "json_parser.hpp"
 #include "shareable.hpp"
 #include "statsig_compat/async/async_helper.hpp"
+#include "statsig_compat/constants/constants.h"
+#include "statsig_compat/defines/module_definitions.h"
+#include "statsig_compat/network/network_client.hpp"
 #include "statsig_compat/output_logger/log.hpp"
+#include "unordered_map_util.hpp"
 
 #ifndef STATSIG_UNREAL_PLUGIN
 #ifdef __unix__
@@ -108,7 +109,7 @@ class ErrorBoundary {
   }
 
  private:
-  static Shareable<ErrorBoundary> shareable_;
+  STATSIG_EXPORT static Shareable<ErrorBoundary> shareable_;
 
   string sdk_key_;
   std::set<string> seen_;
@@ -199,7 +200,5 @@ class ErrorBoundary {
 #endif
   }
 };
-
-Shareable<ErrorBoundary> ErrorBoundary::shareable_ = Shareable<ErrorBoundary>();
 
 }

--- a/src/statsig/internal/error_boundary_request_args.h
+++ b/src/statsig/internal/error_boundary_request_args.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 #include <optional>
+#include <unordered_map>
 
 namespace statsig::internal {
 

--- a/src/statsig/internal/evaluation_details_internal.hpp
+++ b/src/statsig/internal/evaluation_details_internal.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
 #include "../evaluation_details.h"
+#include "evaluations_data_adapter.h"
+#include "statsig_compat/primitives/string.hpp"
 
 namespace statsig::internal::evaluation_details {
 
-String GetValueSourceString(const ValueSource &source) {
+inline String GetValueSourceString(const ValueSource &source) {
   switch (source) {
     case ValueSource::Uninitialized:return "Uninitialized";
     case ValueSource::Loading:return "Loading";
@@ -24,11 +26,11 @@ struct SourceInfo {
   time_t received_at;
 };
 
-EvaluationDetails Uninitialized() {
+inline EvaluationDetails Uninitialized() {
   return {"Uninitialized", 0, 0};
 }
 
-EvaluationDetails UnrecognizedFromSourceInfo(SourceInfo info) {
+inline EvaluationDetails UnrecognizedFromSourceInfo(SourceInfo info) {
   auto result = GetValueSourceString(info.source);
 
   if (info.source == ValueSource::Uninitialized || info.source == ValueSource::NoValues) {
@@ -38,7 +40,7 @@ EvaluationDetails UnrecognizedFromSourceInfo(SourceInfo info) {
   return {result + ":Unrecognized", info.lcut, info.received_at};
 }
 
-EvaluationDetails RecognizedFromSourceInfo(SourceInfo info) {
+inline EvaluationDetails RecognizedFromSourceInfo(SourceInfo info) {
   auto result = GetValueSourceString(info.source);
   return {result + ":Recognized", info.lcut, info.received_at};
 }

--- a/src/statsig/internal/evaluation_details_internal.hpp
+++ b/src/statsig/internal/evaluation_details_internal.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "../evaluation_details.h"
-#include "evaluations_data_adapter.h"
+#include "../evaluations_data_adapter.h"
 #include "statsig_compat/primitives/string.hpp"
 
 namespace statsig::internal::evaluation_details {

--- a/src/statsig/internal/evaluation_store.hpp
+++ b/src/statsig/internal/evaluation_store.hpp
@@ -3,9 +3,12 @@
 #include <string>
 #include <shared_mutex>
 
-#include "hashing.hpp"
-#include "macros.hpp"
 #include "../evaluations_data_adapter.h"
+#include "detailed_evaluation.h"
+#include "hashing.hpp"
+#include "initialize_response.hpp"
+#include "json_parser.hpp"
+#include "macros.hpp"
 #include "evaluation_details_internal.hpp"
 #include "unordered_map_util.hpp"
 

--- a/src/statsig/internal/file.hpp
+++ b/src/statsig/internal/file.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "constants.h"
 #include "statsig_compat/filesystem/file_helper.hpp"
 #include "../statsig_options.h"
 

--- a/src/statsig/internal/hashing.hpp
+++ b/src/statsig/internal/hashing.hpp
@@ -4,7 +4,7 @@
 
 namespace statsig::hashing {
 
-std::string DJB2(const std::string &value) {
+inline std::string DJB2(const std::string &value) {
   unsigned long hash = 0;
   for (char character : value) {
     hash = (hash << 5) - hash + static_cast<unsigned long>(character);

--- a/src/statsig/internal/initialize_request_args.h
+++ b/src/statsig/internal/initialize_request_args.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <string>
+#include <unordered_map>
+
 #include "../statsig_user.h"
 
 namespace statsig::internal {

--- a/src/statsig/internal/network_service.hpp
+++ b/src/statsig/internal/network_service.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+#include <unordered_map>
 #include <utility>
 
 #include "statsig_internal.h"
@@ -110,7 +112,7 @@ class NetworkService {
 
  private:
   string sdk_key_;
-  StatsigOptions &options_;
+  StatsigOptions options_;
   std::shared_ptr<Diagnostics> diagnostics_;
   ErrorBoundary err_boundary_;
   string session_id_;
@@ -131,13 +133,14 @@ class NetworkService {
   }
 
   std::unordered_map<string, string> GetHeaders() {
-    return {
+    std::unordered_map<string, string> headers(GetDefaultPlatformHeaders());
+    headers.merge(std::unordered_map<string, string>{
         {"STATSIG-API-KEY", sdk_key_},
         {"STATSIG-CLIENT-TIME", std::to_string(Time::now())},
         {"STATSIG-SERVER-SESSION-ID", session_id_},
         {"STATSIG-SDK-TYPE", statsig_compatibility::constants::kSdkType},
-        {"STATSIG-SDK-VERSION", constants::kSdkVersion},
-        {"Accept-Encoding", "gzip"}};
+        {"STATSIG-SDK-VERSION", constants::kSdkVersion}});
+    return headers;
   }
 
   std::unordered_map<string, string> GetStatsigMetadata() {

--- a/src/statsig/internal/shareable.hpp
+++ b/src/statsig/internal/shareable.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <mutex>
 #include <unordered_map>
 

--- a/src/statsig/internal/stable_id.hpp
+++ b/src/statsig/internal/stable_id.hpp
@@ -4,6 +4,7 @@
 
 #include "file.hpp"
 #include "error_boundary.hpp"
+#include "uuid.hpp"
 
 namespace statsig::internal {
 
@@ -49,7 +50,7 @@ class StableID {
  private:
   std::optional<std::string> stable_id_;
   std::string sdk_key_;
-  StatsigOptions &options_;
+  StatsigOptions options_;
 };
 
 }

--- a/src/statsig/internal/statsig_event_internal.hpp
+++ b/src/statsig/internal/statsig_event_internal.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
 #include <string>
-#include "statsig_user_internal.hpp"
+
+#include "../statsig_event.h"
+#include "detailed_evaluation.h"
 #include "initialize_response.hpp"
 #include "macros.hpp"
-#include "detailed_evaluation.h"
+#include "statsig_user_internal.hpp"
 #include "time.hpp"
 
 namespace statsig::internal {
@@ -34,7 +36,7 @@ struct RetryableEventPayload {
   std::vector<StatsigEventInternal> events;
 };
 
-inline StatsigEventInternal InternalizeEvent(StatsigEvent event,
+inline StatsigEventInternal InternalizeEvent(const StatsigEvent &event,
                                              const StatsigUser &user) {
   StatsigEventInternal result;
   result.event_name = FromCompat(event.event_name);

--- a/src/statsig/internal/statsig_types.cpp
+++ b/src/statsig/internal/statsig_types.cpp
@@ -32,7 +32,7 @@ std::optional<String> Experiment::GetGroupName() {
 
 std::optional<JsonValue> Layer::GetValue(const std::string &parameter_name) {
   log_param_exposure_(parameter_name);
-  return GetJsonValueFromJsonObject(parameter_name, value_);
+  return GetJsonValueFromJsonObject(ToCompat(parameter_name), value_);
 }
 
 std::optional<String> Layer::GetGroupName() {

--- a/src/statsig/internal/statsig_user_internal.hpp
+++ b/src/statsig/internal/statsig_user_internal.hpp
@@ -1,9 +1,12 @@
 #pragma once
 
-#include "hashing.hpp"
-#include "../statsig_user.h"
-#include "statsig_compat/primitives/string.hpp"
+#include <algorithm>
 #include <numeric>
+
+#include "../statsig_options.h"
+#include "../statsig_user.h"
+#include "hashing.hpp"
+#include "statsig_compat/primitives/string.hpp"
 
 namespace statsig::internal {
 

--- a/src/statsig/internal/unordered_map_util.hpp
+++ b/src/statsig/internal/unordered_map_util.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <unordered_map>
 
 namespace statsig::internal {

--- a/src/statsig/log_level.h
+++ b/src/statsig/log_level.h
@@ -1,11 +1,5 @@
 #pragma once
 
-#ifdef STATSIG_UNREAL_PLUGIN
-#include "Logging/LogMacros.h"
-DECLARE_LOG_CATEGORY_EXTERN(LogStatsig, Log, All);
-inline DEFINE_LOG_CATEGORY(LogStatsig);
-#endif
-
 namespace statsig {
 
 enum LogLevel: int {

--- a/src/statsig/statsig.h
+++ b/src/statsig/statsig.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <optional>
-
 #include "statsig_result.h"
 #include "statsig_user.h"
 #include "statsig_types.h"

--- a/src/statsig/statsig_client.h
+++ b/src/statsig/statsig_client.h
@@ -1,13 +1,16 @@
 #pragma once
 
+#include <memory>
+
+#include "statsig_compat/defines/module_definitions.h"
 #include "statsig_compat/primitives/string.hpp"
-#include "./statsig.h"
+#include "statsig.h"
 
 namespace statsig {
 
 class StatsigContext;
 
-class StatsigClient {
+class STATSIG_EXPORT StatsigClient {
  public:
   static StatsigClient &Shared();
   StatsigClient();

--- a/src/statsig/statsig_environment.h
+++ b/src/statsig/statsig_environment.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include "statsig_compat/primitives/string.hpp"
 
 namespace statsig {

--- a/src/statsig/statsig_event.h
+++ b/src/statsig/statsig_event.h
@@ -1,8 +1,10 @@
 #pragma once
 
-#include <utility>
+#include <optional>
 #include <unordered_map>
+#include <utility>
 
+#include "statsig_compat/primitives/map.hpp"
 #include "statsig_compat/primitives/string.hpp"
 
 namespace statsig {

--- a/src/statsig/statsig_options.h
+++ b/src/statsig/statsig_options.h
@@ -6,7 +6,6 @@
 #include "statsig_compat/primitives/string.hpp"
 #include "statsig_compat/primitives/file_path.hpp"
 
-#include "evaluations_data_adapter.h"
 #include "log_level.h"
 #include "statsig_environment.h"
 

--- a/src/statsig/statsig_types.h
+++ b/src/statsig/statsig_types.h
@@ -4,12 +4,13 @@
 #include <functional>
 
 #include "evaluation_details.h"
+#include "statsig_compat/defines/module_definitions.h"
 #include "statsig_compat/primitives/json_value.hpp"
 #include "statsig_compat/primitives/string.hpp"
 
 namespace statsig {
 
-class BaseSpec {
+class STATSIG_EXPORT BaseSpec {
  public:
   String GetName();
 
@@ -58,21 +59,21 @@ class EvaluatedSpec : public BaseSpec {
   std::optional<String> group_name_;
 };
 
-class FeatureGate : public EvaluatedSpec<bool> {
+class STATSIG_EXPORT FeatureGate : public EvaluatedSpec<bool> {
  public:
   bool GetValue();
 
   using EvaluatedSpec::EvaluatedSpec;
 };
 
-class DynamicConfig : public EvaluatedSpec<JsonObject> {
+class STATSIG_EXPORT DynamicConfig : public EvaluatedSpec<JsonObject> {
  public:
   JsonObject GetValues();
 
   using EvaluatedSpec::EvaluatedSpec;
 };
 
-class Experiment : public EvaluatedSpec<JsonObject> {
+class STATSIG_EXPORT Experiment : public EvaluatedSpec<JsonObject> {
  public:
   JsonObject GetValues();
 
@@ -81,7 +82,7 @@ class Experiment : public EvaluatedSpec<JsonObject> {
   using EvaluatedSpec::EvaluatedSpec;
 };
 
-class Layer : public EvaluatedSpec<JsonObject> {
+class STATSIG_EXPORT Layer : public EvaluatedSpec<JsonObject> {
   friend class StatsigClient;
 
  public:

--- a/src/statsig/statsig_user.h
+++ b/src/statsig/statsig_user.h
@@ -3,6 +3,7 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+
 #include "statsig_environment.h"
 
 #include "statsig_compat/primitives/string.hpp"

--- a/src/statsig_compat/async/async_helper.cpp
+++ b/src/statsig_compat/async/async_helper.cpp
@@ -1,0 +1,11 @@
+#if !STATSIG_WITH_COMPATIBILITY_OVERRIDE
+#include "async_helper.hpp"
+
+namespace statsig_compatibility {
+
+statsig::internal::Shareable<AsyncHelper> AsyncHelper::shareable_ =
+    statsig::internal::Shareable<AsyncHelper>();
+
+}
+
+#endif

--- a/src/statsig_compat/async/async_helper.hpp
+++ b/src/statsig_compat/async/async_helper.hpp
@@ -1,11 +1,12 @@
 #pragma once
 
-#include <functional>
 #include <atomic>
-#include <thread>
-#include <queue>
-#include <mutex>
 #include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <optional>
+#include <queue>
+#include <thread>
 #include <vector>
 
 #include "../output_logger/log.hpp"
@@ -222,7 +223,5 @@ class AsyncHelper {
   static statsig::internal::Shareable<AsyncHelper> shareable_;
   ThreadPool thread_pool_{};
 };
-
-statsig::internal::Shareable<AsyncHelper> AsyncHelper::shareable_ = statsig::internal::Shareable<AsyncHelper>();
 
 }

--- a/src/statsig_compat/constants/constants.h
+++ b/src/statsig_compat/constants/constants.h
@@ -3,6 +3,6 @@
 namespace statsig_compatibility::constants {
 
 // Statsig Metadata
-const char *kSdkType = "cpp-client";
+static const char *kSdkType = "cpp-client";
 
 }

--- a/src/statsig_compat/defines/module_definitions.h
+++ b/src/statsig_compat/defines/module_definitions.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#define STATSIG_EXPORT 

--- a/src/statsig_compat/filesystem/file_helper.hpp
+++ b/src/statsig_compat/filesystem/file_helper.hpp
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include <string>
 #include <optional>

--- a/src/statsig_compat/json_serialization/data_adapter_result_json.hpp
+++ b/src/statsig_compat/json_serialization/data_adapter_result_json.hpp
@@ -6,7 +6,7 @@
 
 namespace statsig::data_types::data_adapter_result {
 
-StatsigResult<std::string> Serialize(const DataAdapterResult &res) {
+inline StatsigResult<std::string> Serialize(const DataAdapterResult &res) {
   auto j = nlohmann::json{
       {"source", res.source},
       {"data", res.data},
@@ -16,7 +16,7 @@ StatsigResult<std::string> Serialize(const DataAdapterResult &res) {
   return {Ok, j.dump()};
 }
 
-StatsigResult<DataAdapterResult> Deserialize(const std::string &input) {
+inline StatsigResult<DataAdapterResult> Deserialize(const std::string &input) {
   try {
     auto j = nlohmann::json::parse(input);
     DataAdapterResult res;

--- a/src/statsig_compat/json_serialization/error_boundary_request_args_json.hpp
+++ b/src/statsig_compat/json_serialization/error_boundary_request_args_json.hpp
@@ -6,7 +6,7 @@
 
 namespace statsig::data_types::error_boundary_request_args {
 
-StatsigResult<std::string> Serialize(const internal::ErrorBoundaryRequestArgs &args) {
+inline StatsigResult<std::string> Serialize(const internal::ErrorBoundaryRequestArgs &args) {
   auto j = nlohmann::json{
       {"tag", args.tag},
       {"exception", args.exception},

--- a/src/statsig_compat/json_serialization/initialize_request_args_json.hpp
+++ b/src/statsig_compat/json_serialization/initialize_request_args_json.hpp
@@ -7,7 +7,7 @@
 
 namespace statsig::data_types::initialize_request_args {
 
-StatsigResult<std::string> Serialize(const internal::InitializeRequestArgs &args) {
+inline StatsigResult<std::string> Serialize(const internal::InitializeRequestArgs &args) {
   auto j = nlohmann::json{
       {"hash", args.hash},
       {"user", statsig_user::ToJson(args.user)},

--- a/src/statsig_compat/json_serialization/initialize_response_json.hpp
+++ b/src/statsig_compat/json_serialization/initialize_response_json.hpp
@@ -8,7 +8,7 @@ namespace statsig::data_types {
 
 namespace gate_evaluation {
 
-statsig::data::GateEvaluation FromJson(const nlohmann::json &j) {
+inline statsig::data::GateEvaluation FromJson(const nlohmann::json &j) {
   statsig::data::GateEvaluation e;
 
   j.at("name").get_to(e.name);
@@ -27,7 +27,7 @@ statsig::data::GateEvaluation FromJson(const nlohmann::json &j) {
 
 namespace config_evaluation {
 
-statsig::data::ConfigEvaluation FromJson(const nlohmann::json &j) {
+inline statsig::data::ConfigEvaluation FromJson(const nlohmann::json &j) {
   statsig::data::ConfigEvaluation e;
   j.at("name").get_to(e.name);
   j.at("rule_id").get_to(e.rule_id);
@@ -45,7 +45,7 @@ statsig::data::ConfigEvaluation FromJson(const nlohmann::json &j) {
 
 namespace layer_evaluation {
 
-statsig::data::LayerEvaluation FromJson(const nlohmann::json &j) {
+inline statsig::data::LayerEvaluation FromJson(const nlohmann::json &j) {
   statsig::data::LayerEvaluation e;
 
   j.at("name").get_to(e.name);
@@ -72,7 +72,7 @@ namespace initialize_response {
 
 using namespace statsig::data;
 
-InitializeResponse FromJson(const nlohmann::json &j) {
+inline InitializeResponse FromJson(const nlohmann::json &j) {
   InitializeResponse response;
 
   using JMap = std::unordered_map<std::string, nlohmann::json>;
@@ -106,7 +106,7 @@ InitializeResponse FromJson(const nlohmann::json &j) {
 //  return ToJson(response).dump();
 //}
 
-StatsigResult<InitializeResponse> Deserialize(const std::string &input) {
+inline StatsigResult<InitializeResponse> Deserialize(const std::string &input) {
   try {
     auto j = nlohmann::json::parse(input);
     return {Ok, FromJson(j)};

--- a/src/statsig_compat/json_serialization/statsig_event_json.hpp
+++ b/src/statsig_compat/json_serialization/statsig_event_json.hpp
@@ -7,7 +7,7 @@ namespace statsig::data_types::statsig_event {
 
 using StatsigEventInternal = internal::StatsigEventInternal;
 
-nlohmann::json ToJson(const StatsigEventInternal &event) {
+inline nlohmann::json ToJson(const StatsigEventInternal &event) {
   auto j = nlohmann::json{
       {"eventName", event.event_name},
       {"time", event.time},
@@ -31,7 +31,7 @@ nlohmann::json ToJson(const StatsigEventInternal &event) {
   return j;
 }
 
-StatsigEventInternal FromJson(const nlohmann::json &json) {
+inline StatsigEventInternal FromJson(const nlohmann::json &json) {
   StatsigEventInternal result;
 
   json.at("eventName").get_to(result.event_name);

--- a/src/statsig_compat/json_serialization/statsig_user_json.hpp
+++ b/src/statsig_compat/json_serialization/statsig_user_json.hpp
@@ -11,19 +11,19 @@ namespace statsig::data_types::statsig_user {
 #define OPT_STR_FROM_JSON(jsonObj, fieldName, target) do { if (jsonObj.contains(fieldName)) { target = jsonObj[fieldName].get<std::string>(); } } while(0)
 #define OPT_STR_MAP_FROM_JSON(jsonObj, fieldName, target) do { if (jsonObj.contains(fieldName)) { target = jsonObj[fieldName].get<std::unordered_map<std::string, std::string>>(); } } while(0)
 
-nlohmann::json EnvToJson(const StatsigEnvironment &e) {
+inline nlohmann::json EnvToJson(const StatsigEnvironment &e) {
   auto j = nlohmann::json{};
   OPT_TO_JSON(j, tier, e.tier);
   return j;
 }
 
-StatsigEnvironment EnvFromJson(const nlohmann::json &j) {
+inline StatsigEnvironment EnvFromJson(const nlohmann::json &j) {
   StatsigEnvironment u;
   OPT_STR_FROM_JSON(j, "tier", u.tier);
   return u;
 }
 
-nlohmann::json ToJson(const StatsigUser &u) {
+inline nlohmann::json ToJson(const StatsigUser &u) {
   auto j = nlohmann::json{};
 
   if (!u.custom_ids.empty()) {
@@ -47,7 +47,7 @@ nlohmann::json ToJson(const StatsigUser &u) {
   return j;
 }
 
-StatsigUser FromJson(const nlohmann::json &j) {
+inline StatsigUser FromJson(const nlohmann::json &j) {
   StatsigUser u;
   u.user_id = j.value("userID", "");
   u.custom_ids = j.value("customIDs", std::unordered_map<std::string, std::string>());
@@ -68,11 +68,11 @@ StatsigUser FromJson(const nlohmann::json &j) {
   return u;
 }
 
-StatsigResult<std::string> Serialize(const StatsigUser &user) {
+inline StatsigResult<std::string> Serialize(const StatsigUser &user) {
   return {Ok, ToJson(user).dump()};
 }
 
-StatsigResult<StatsigUser> Deserialize(const std::string &input) {
+inline StatsigResult<StatsigUser> Deserialize(const std::string &input) {
   try {
     auto j = nlohmann::json::parse(input);
     auto user = FromJson(j);

--- a/src/statsig_compat/network/network_client.hpp
+++ b/src/statsig_compat/network/network_client.hpp
@@ -2,12 +2,17 @@
 
 #include <functional>
 #include <optional>
-#include <utility>
+#include <string>
+#include <unordered_map>
 
 #include "httplib.h"
 #include "statsig/internal/constants.h"
 
 namespace statsig::internal {
+
+inline std::unordered_map<std::string, std::string> GetDefaultPlatformHeaders() {
+  return {{"Accept-Encoding", "gzip"}};
+}
 
 struct HttpResponse {
   const std::string text;

--- a/src/statsig_compat/output_logger/log.cpp
+++ b/src/statsig_compat/output_logger/log.cpp
@@ -1,0 +1,10 @@
+#if !STATSIG_WITH_COMPATIBILITY_OVERRIDE
+#include "log.hpp"
+
+namespace statsig_compatibility {
+
+LogLevel Log::level = LogLevel::Error;
+
+}
+
+#endif

--- a/src/statsig_compat/output_logger/log.hpp
+++ b/src/statsig_compat/output_logger/log.hpp
@@ -36,6 +36,4 @@ public:
   }
 };
 
-LogLevel Log::level = LogLevel::Error;
-
 }

--- a/src/statsig_compat/platform/platform_events_helper.cpp
+++ b/src/statsig_compat/platform/platform_events_helper.cpp
@@ -1,0 +1,12 @@
+#if !STATSIG_WITH_COMPATIBILITY_OVERRIDE
+
+#include "platform_events_helper.hpp"
+
+namespace statsig_compatibility {
+
+statsig::internal::Shareable<PlatformEventsHelper> PlatformEventsHelper::shareable_ =
+    statsig::internal::Shareable<PlatformEventsHelper>();
+
+}
+
+#endif

--- a/src/statsig_compat/platform/platform_events_helper.hpp
+++ b/src/statsig_compat/platform/platform_events_helper.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <functional>
+
+#include "internal/shareable.hpp"
+#include "statsig_compat/defines/module_definitions.h"
+
+#include "Misc/CoreDelegates.h"
+#include "Templates/Function.h"
+
+namespace statsig_compatibility {
+
+class PlatformEventRegistrationHandle final {
+public:
+  PlatformEventRegistrationHandle() = default;
+  ~PlatformEventRegistrationHandle() = default;
+
+  void Reset() {
+    // no-op
+  }
+};
+
+class PlatformEventsHelper {
+ public:
+  static std::shared_ptr<PlatformEventsHelper> Get(const std::string &sdk_key) {
+    auto instance = shareable_.Get(sdk_key);
+    if (instance != nullptr) {
+      return instance;
+    }
+
+    std::shared_ptr<PlatformEventsHelper> new_instance(new PlatformEventsHelper());
+    shareable_.Add(sdk_key, new_instance);
+    return new_instance;
+  }
+
+  PlatformEventRegistrationHandle RegisterOnApplicationWillDeactivateCallback(const std::function<void()> &callback) {
+    // no-op
+    return PlatformEventRegistrationHandle();
+  }
+
+  PlatformEventRegistrationHandle RegisterOnApplicationWillEnterBackgroundCallback(const std::function<void()> &callback) {
+    // no-op
+    return PlatformEventRegistrationHandle();
+  }
+
+ private:
+  STATSIG_EXPORT static statsig::internal::Shareable<PlatformEventsHelper> shareable_;
+};
+
+}

--- a/src/statsig_compat/platform/platform_events_helper.hpp
+++ b/src/statsig_compat/platform/platform_events_helper.hpp
@@ -2,11 +2,8 @@
 
 #include <functional>
 
-#include "internal/shareable.hpp"
+#include "statsig/internal/shareable.hpp"
 #include "statsig_compat/defines/module_definitions.h"
-
-#include "Misc/CoreDelegates.h"
-#include "Templates/Function.h"
 
 namespace statsig_compatibility {
 

--- a/src/statsig_compat/primitives/json_value.hpp
+++ b/src/statsig_compat/primitives/json_value.hpp
@@ -11,7 +11,7 @@ typedef nlohmann::json JsonValue;
 typedef nlohmann::ordered_json JsonObject;
 
 inline JsonValue GetJsonValueFromJsonObject(
-    const std::string &key,
+    const String &key,
     const JsonObject &object) {
   if (object.is_object()) {
     return object[key];

--- a/src/statsig_compat/primitives/map.hpp
+++ b/src/statsig_compat/primitives/map.hpp
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace statsig {


### PR DESCRIPTION
Change background flusher to use a scheduled timer.
Fix linker issues with symbols defined in multiple modules. Add missing header includes.
Add GetDefaultPlatformHeaders to allow the compatibility layer to inject default headers. Move the handling of platform events (application suspend / backgrounded) into PlatformEventsHelper which is usable by the sdk. Fix crash when accessing a json field which is not set. Fix crash on shutdown when flushing events.
Fix string conversion issues.